### PR TITLE
Build kind node locally and upgrade go

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.21'
+          go-version: '1.22'
 
       - name: Test
         run: make test-run-unit
@@ -29,9 +29,6 @@ jobs:
     strategy:
       matrix:
         arg:
-          - '1.28'
-          - '1.29'
-          - '1.30'
           - '1.31'
 
     steps:
@@ -43,7 +40,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.21'
+          go-version: '1.22'
 
       - name: Set up Kind
         uses: helm/kind-action@v1.8.0

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -43,11 +43,10 @@ jobs:
           go-version: '1.22'
 
       - name: Set up Kind
-        uses: helm/kind-action@v1.8.0
+        uses: helm/kind-action@v1.10.0
         with:
           install_only: true
-          version: v0.24.0
-          kubectl_version: v1.31.3
+          version: v0.25.0
 
       - name: Test with Kubernetes ${{ matrix.arg }}
         env:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -46,8 +46,8 @@ jobs:
         uses: helm/kind-action@v1.8.0
         with:
           install_only: true
-          version: v0.20.0
-          kubectl_version: v1.27.2
+          version: v0.25.0
+          kubectl_version: v1.31.3
 
       - name: Test with Kubernetes ${{ matrix.arg }}
         env:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -46,7 +46,7 @@ jobs:
         uses: helm/kind-action@v1.8.0
         with:
           install_only: true
-          version: v0.25.0
+          version: v0.24.0
           kubectl_version: v1.31.3
 
       - name: Test with Kubernetes ${{ matrix.arg }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.22'
+          go-version: '1.22.9'
 
       - name: Test
         run: make test-run-unit
@@ -40,7 +40,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.22'
+          go-version: '1.22.9'
 
       - name: Set up Kind
         uses: helm/kind-action@v1.10.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM --platform=$BUILDPLATFORM golang:1.22 AS build
+FROM --platform=$BUILDPLATFORM golang:1.22.9 AS build
 RUN echo "Build platform: $BUILDPLATFORM, target platform: $TARGETPLATFORM, target OS: $TARGETOS, target arch: $TARGETARCH"
 RUN openssl s_client -showcerts -connect proxy.golang.org:443 </dev/null 2>/dev/null|openssl x509 -outform PEM > /usr/local/share/ca-certificates/goproxy.crt
 RUN update-ca-certificates

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,28 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM --platform=$BUILDPLATFORM golang:1.21 AS build
-
-ARG BUILDPLATFORM
-ARG TARGETPLATFORM
-ARG TARGETOS
-ARG TARGETARCH
+FROM --platform=$BUILDPLATFORM golang:1.22 AS build
 RUN echo "Build platform: $BUILDPLATFORM, target platform: $TARGETPLATFORM, target OS: $TARGETOS, target arch: $TARGETARCH"
-
 RUN openssl s_client -showcerts -connect proxy.golang.org:443 </dev/null 2>/dev/null|openssl x509 -outform PEM > /usr/local/share/ca-certificates/goproxy.crt
 RUN update-ca-certificates
-
 WORKDIR /csa
 COPY go.mod go.sum ./
 RUN go mod download && go mod verify
-
 COPY cmd ./cmd
 COPY internal ./internal
-
 RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -ldflags="-w -s" -o ./csa ./cmd/container-startup-autoscaler
 
-FROM --platform=$TARGETPLATFORM scratch
-
+FROM scratch
 COPY --from=build /csa/csa /csa/csa
 EXPOSE 8080/tcp
 EXPOSE 8081/tcp

--- a/README.md
+++ b/README.md
@@ -504,13 +504,12 @@ top of [go.mod](go.mod).
 
 Integration tests are implemented as Go tests and located in `test/integration`. During initialization of the tests, a
 [kind](https://kind.sigs.k8s.io/) cluster is created (with a specific name); CSA is built via Docker and run via
-[Helm](#helm-chart). Tools are not bundled with the tests, so you must have the following installed locally (test
-development versions indicated):
+[Helm](#helm-chart). Tools are not bundled with the tests, so you must have the following installed locally:
 
-- Docker (24.0.6)
-- Helm (3.13.1)
-- kind (0.20.0)
-- kubectl (1.27.2)
+- Docker
+- Helm
+- kind (at least 0.24.0)
+- kubectl
 
 The integration tests use [echo-server](https://github.com/Ealenn/Echo-Server) for containers. Note: the very first
 execution might take some time to complete.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ExpediaGroup/container-startup-autoscaler
 
-go 1.22
+go 1.22.9
 
 require (
 	github.com/avast/retry-go/v4 v4.5.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ExpediaGroup/container-startup-autoscaler
 
-go 1.21
+go 1.22
 
 require (
 	github.com/avast/retry-go/v4 v4.5.0

--- a/scripts/sandbox/config/vars.sh
+++ b/scripts/sandbox/config/vars.sh
@@ -18,21 +18,10 @@
 
 kind_cluster_name="csa-sandbox-cluster"
 
-arch=$(uname -m)
-case $arch in
-  x86_64)
-    # shellcheck disable=SC2034
-    kind_image="kindest/node:v1.31.0@sha256:919a65376fd11b67df05caa2e60802ad5de2fca250c9fe0c55b0dce5c9591af3"
-    ;;
-  arm64)
-    # shellcheck disable=SC2034
-    kind_image="kindest/node:v1.31.0@sha256:0ccfb11dc66eae4abc20c30ee95687bab51de8aeb04e325e1c49af0890646548"
-    ;;
-  *)
-    echo "Error: architecture '$arch' not supported"
-    exit 1
-    ;;
-esac
+# shellcheck disable=SC2034
+kind_kube_version="v1.31.3"
+# shellcheck disable=SC2034
+kind_node_docker_tag="kindest/node:$kind_kube_version"
 
 # shellcheck disable=SC2034
 kind_kubeconfig="$HOME/.kube/config-$kind_cluster_name"

--- a/scripts/sandbox/csa-install.sh
+++ b/scripts/sandbox/csa-install.sh
@@ -18,10 +18,16 @@ source config/vars.sh
 source csa-uninstall.sh
 
 # shellcheck disable=SC2154
+if [ -z "$(docker images --filter "reference=$kind_node_docker_tag" --format '{{.Repository}}:{{.Tag}}')" ]; then
+  # shellcheck disable=SC2154
+  kind build node-image --type release "$kind_kube_version" --image "$kind_node_docker_tag"
+fi
+
+# shellcheck disable=SC2154
 kind create cluster \
      --name="$kind_cluster_name" \
      --config=config/kind.yaml \
-     --image="$kind_image"
+     --image="$kind_node_docker_tag"
 
 # shellcheck disable=SC2154
 kind get kubeconfig --name "$kind_cluster_name" > "$kind_kubeconfig"

--- a/test/integration/consts.go
+++ b/test/integration/consts.go
@@ -31,23 +31,10 @@ const (
 	kindConfigFileRelPath = pathConfigDirRelPath + pathSeparator + "kind.yaml"
 )
 
-var k8sVersionToImage = map[string]map[string]string{
-	"1.31": {
-		"amd64": "kindest/node:v1.31.0@sha256:919a65376fd11b67df05caa2e60802ad5de2fca250c9fe0c55b0dce5c9591af3",
-		"arm64": "kindest/node:v1.31.0@sha256:0ccfb11dc66eae4abc20c30ee95687bab51de8aeb04e325e1c49af0890646548",
-	},
-	"1.30": {
-		"amd64": "kindest/node:v1.30.4@sha256:34cb98a38a57a3357fde925a41d61232bbbbeb411b45a25c0d766635d6c3b975",
-		"arm64": "kindest/node:v1.30.4@sha256:6becd630a18e77730e31f3833f0b129bbcc9c09ee49c3b88429b3c1fdc30bfc4",
-	},
-	"1.29": {
-		"amd64": "kindest/node:v1.29.8@sha256:b69a150f9951ef41158ec76de381a920df2be3582fd16fc19cf4757eef0dded9",
-		"arm64": "kindest/node:v1.29.8@sha256:0d5623800cf6290edbc1007ca8a33a5f7e2ad92b41dc7022b4d20a66447db23c",
-	},
-	"1.28": {
-		"amd64": "kindest/node:v1.28.13@sha256:d97df9fff48099bf9a94c92fdc39adde65bec2aa1d011f84233b96172c1003c9",
-		"arm64": "kindest/node:v1.28.13@sha256:ddef612bb93a9aa3a989f9d3d4e01c0a7c4d866a4b949264146c182cd202d738",
-	},
+var kubeVersionToFullVersion = map[string]string{
+	"1.31": "v1.31.3",
+	// Older versions are not supported by 'kind build node-image' as the server tgzs don't include the 'version' file
+	// and fail.
 }
 
 // metrics-server ------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
- Builds kind node locally instead of relying on pre-built images (greater flexibility on versions).
  - `kind build node-image` does not support kube versions older than 1.31 (missing `version` file in tgz) so these have been removed from the integration tests - they would have been anyway with upcoming https://github.com/kubernetes/kubernetes/pull/128266.
- Upgrades go to 1.22.9.